### PR TITLE
Added a route helper

### DIFF
--- a/lib/G/classes/class.handler.php
+++ b/lib/G/classes/class.handler.php
@@ -425,6 +425,19 @@ class Handler {
 	public static function getTemplateUsed() {
 		return self::$template_used;
 	}
+	
+	/**
+	 * G -> get_route_name() is single 
+	 * Example (G\get_route_name() == 'page/tos') ? "yes" : "no"; <-- No G\get_route_name() = Index request i.e page
+	 * This extends theme developers for a current page mapped in the array
+	 * for a real path the $route is on.
+	 * Example (self::getMappedRoute() == 'page/tos') ? "yes" : "no"; <-- makes array string to match
+	 * @return array|string
+	 */
+	public static function getMappedRoute() {
+		// $sub_routes == array from G\Handler::$route join array as string with / to match current $route
+		return (is_array(G\Handler::$route)) ? implode("/", G\Handler::$route) : G\Handler::$route;	
+	}
 
 }
 

--- a/lib/G/classes/class.handler.php
+++ b/lib/G/classes/class.handler.php
@@ -436,7 +436,7 @@ class Handler {
 	 */
 	public static function getMappedRoute() {
 		// $sub_routes == array from G\Handler::$route join array as string with / to match current $route
-		return (is_array(G\Handler::$route)) ? implode("/", G\Handler::$route) : G\Handler::$route;	
+		return (is_array(self::$route)) ? implode("/", self::$route) : self::$route;	
 	}
 
 }


### PR DESCRIPTION
This addition helps devs i.e theme developers to match if a route with a sub_route(s) i.e page/contact is current than the current index request from G\get_route_name(); // page

<?php if(G\get_route_name() == 'explore') { ?> current<?php } ?>"> // True
<?php if(G\get_route_name() == 'page') { ?> current<?php } ?>"> // True
<?php if(G\get_route_name() == 'page/contact') { ?> current<?php } ?>"> // False /contact is array in page

<?php if(G\Handler::getMappedRoute() == 'page/contact') { ?> class="current"<?php } ?> //True array is now string to match with /